### PR TITLE
Fix mismatched BeginDisabled/EndDisabled

### DIFF
--- a/Orchestrion/UI/Windows/MainWindow/MainWindow.Root.cs
+++ b/Orchestrion/UI/Windows/MainWindow/MainWindow.Root.cs
@@ -186,10 +186,10 @@ public partial class MainWindow : Window, IDisposable
 
 		ImGui.SetCursorPosY(ImGui.GetWindowSize().Y - buttonHeight - ImGui.GetStyle().WindowPadding.Y);
 
-		if (BGMManager.PlayingSongId == 0) ImGui.BeginDisabled();
+		ImGui.BeginDisabled(BGMManager.PlayingSongId == 0);
 		if (ImGui.Button(stopText, new Vector2(width / 2, buttonHeight)))
 			BGMManager.Stop();
-		if (BGMManager.PlayingSongId == 0) ImGui.EndDisabled();
+		ImGui.EndDisabled();
 
 		ImGui.SameLine();
 


### PR DESCRIPTION
On the frame where you click the stop button, the first `if` will evaluate to false (because a song is playing), but then the second `if` will evaluate to true (since a song is now no longer playing), meaning we call EndDisabled without having called BeginDisabled.

Switched to passing the predicate into the BeginDisabled function, similar to the play button.

I'm also happy to rewrite things to use ImRaii instead if you'd prefer that, but decided to start out with the smaller change.