### PR TITLE
feature: report estate Orchestrion song names

### DIFF
--- a/Orchestrion/Audio/BGMManager.cs
+++ b/Orchestrion/Audio/BGMManager.cs
@@ -1,7 +1,7 @@
-﻿using CheapLoc;
-using Dalamud.Logging;
+using CheapLoc;
 using Dalamud.Plugin.Services;
 using Orchestrion.BGMSystem;
+using Orchestrion.InnSystem;
 using Orchestrion.Ipc;
 using Orchestrion.Persistence;
 using Orchestrion.Types;
@@ -10,7 +10,8 @@ namespace Orchestrion.Audio;
 
 public static class BGMManager
 {
-	private static readonly BGMController _bgmController;
+    private static readonly BGMController _bgmController;
+    private static readonly OrchestrionInnController _innController;
     private static readonly OrchestrionIpcManager _ipcManager;
     
     private static bool _isPlayingReplacement;
@@ -18,6 +19,9 @@ public static class BGMManager
 
     public delegate void SongChanged(int oldSong, int currentSong, int oldSecondSong, int oldCurrentSong, bool oldPlayedByOrch, bool playedByOrchestrion);
     public static event SongChanged OnSongChanged;
+
+    public delegate void InnSongPlayed(string trackDtrName, string trackChatName);
+    public static event InnSongPlayed OnInnSongPlayed;
     
     public static int CurrentSongId => _bgmController.CurrentSongId;
     public static int PlayingSongId => _bgmController.PlayingSongId;
@@ -25,12 +29,14 @@ public static class BGMManager
     public static int PlayingScene => _bgmController.PlayingScene;
     
     static BGMManager()
-	{
+    {
         _bgmController = new BGMController();
+        _innController = new OrchestrionInnController();
         _ipcManager = new OrchestrionIpcManager();
 
         DalamudApi.Framework.Update += Update;
         _bgmController.OnSongChanged += HandleSongChanged;
+        _innController.OnPlayingSongChanged += HandleInnSongChanged;
         OnSongChanged += IpcUpdate;
     }
 
@@ -38,6 +44,9 @@ public static class BGMManager
     {
         DalamudApi.Framework.Update -= Update;
         Stop();
+        OnSongChanged -= IpcUpdate;
+        _innController.OnPlayingSongChanged -= HandleInnSongChanged;
+        _bgmController.OnSongChanged -= HandleSongChanged;
         _bgmController.Dispose();
     }
 
@@ -49,11 +58,31 @@ public static class BGMManager
     
     public static void Update(IFramework ignored)
     {
+        _innController.Update();
         _bgmController.Update();
     }
     
+    private static void HandleInnSongChanged(uint oldInnPlayingTrackId, uint newInnPlayingTrackId, string oldInnTrackDtrName, string newInnTrackDtrName, string newInnTrackChatName)
+    {
+        if (newInnPlayingTrackId > 0)
+        {
+            // Estate orchestrions play over BGM, so trying to play BGM now is useless
+            Stop();
+            DalamudApi.PluginLog.Debug($"[BGMManager::HandleInnSongChanged] Inn song changed from {oldInnPlayingTrackId} - '{oldInnTrackDtrName}' to {newInnPlayingTrackId} - '{newInnTrackChatName}'");
+            OnInnSongPlayed.Invoke(newInnTrackDtrName, newInnTrackChatName);
+        }
+        else
+        {
+            // Force update for BGM Manager
+            HandleSongChanged(0, _bgmController.CurrentSongId, _bgmController.OldSecondSongId, _bgmController.SecondSongId);
+        }
+    }
+
     private static void HandleSongChanged(int oldSong, int newSong, int oldSecondSong, int newSecondSong)
     {
+        // Estate orchestrions play over BGM, so trying to handle BGM now is useless
+        if (InnMusicActive()) return;
+
         var currentChanged = oldSong != newSong;
         var secondChanged = oldSecondSong != newSecondSong;
         
@@ -68,10 +97,13 @@ public static class BGMManager
         
         if (PlayingSongId != 0 && DeepDungeonModeActive())
         {
-            if (!string.IsNullOrEmpty(_ddPlaylist) && !Configuration.Instance.Playlists.ContainsKey(_ddPlaylist)) // user deleted playlist
-                Stop();
-            else
-                PlayRandomSong(_ddPlaylist);
+            if (!string.IsNullOrEmpty(_ddPlaylist))
+            {
+                if (!Configuration.Instance.Playlists.ContainsKey(_ddPlaylist)) // user deleted playlist
+                    Stop();
+                else
+                    PlayRandomSong(_ddPlaylist);
+            }
             return;
         }
 
@@ -83,7 +115,7 @@ public static class BGMManager
             if (PlayingSongId != 0)
                 Stop();
             else
-                // This is the only place in this method where we invoke OnSongChanged, as Play and Stop do it themselves
+                // Play and Stop invoke OnSongChanged themselves
                 InvokeSongChanged(oldSong, newSong, oldSecondSong, newSecondSong, oldPlayedByOrch: false, playedByOrch: false);
             return;
         }
@@ -117,6 +149,9 @@ public static class BGMManager
 
     public static void Play(int songId, bool isReplacement = false)
     {
+        // Estate orchestrions play over BGM, so trying to play BGM now is useless
+        if (InnMusicActive()) return;
+
         var wasPlaying = PlayingSongId != 0;
         var oldSongId = CurrentAudibleSong;
         var secondSongId = _bgmController.SecondSongId;
@@ -190,5 +225,10 @@ public static class BGMManager
     public static bool DeepDungeonModeActive()
     {
         return _ddPlaylist != null;
+    }
+
+    public static bool InnMusicActive()
+    {
+        return  _innController.IsInnTrackPlaying();
     }
 }

--- a/Orchestrion/Audio/PlaylistManager.cs
+++ b/Orchestrion/Audio/PlaylistManager.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using Dalamud.Logging;
+using System.Collections.Generic;
 using Dalamud.Plugin.Services;
 using Orchestrion.Persistence;
 using Orchestrion.Types;
@@ -9,7 +8,7 @@ namespace Orchestrion.Audio;
 public static class PlaylistManager
 {
 	public static bool IsPlaying { get; private set; }
-	public static Playlist CurrentPlaylist => Configuration.Instance.Playlists.GetValueOrDefault(_currentPlaylist, null);
+	public static Playlist? CurrentPlaylist => Configuration.Instance.Playlists.GetValueOrDefault(_currentPlaylist, null);
 	public static int CurrentSongId => CurrentPlaylist?.Songs[_currentSongIndex] ?? 0;
 	public static int CurrentSongIndex => _currentSongIndex;
 	public static Song CurrentSong => SongList.Instance.GetSong(CurrentPlaylist?.Songs[_currentSongIndex] ?? 0);
@@ -51,12 +50,14 @@ public static class PlaylistManager
 	
 	public static void Play(string playlistName)
 	{
+		if (BGMManager.InnMusicActive()) return;
 		Set(playlistName, -1, isPlaying: true);
 		Next();
 	}
 
 	public static void Play(string playlistName, int index)
 	{
+		if (BGMManager.InnMusicActive()) return;
 		Set(playlistName, index, isPlaying: true);
 		BGMManager.Play(CurrentPlaylist.Songs[index]);
 		_currentSongStartTime = Environment.TickCount64;

--- a/Orchestrion/BGMSystem/BGMController.cs
+++ b/Orchestrion/BGMSystem/BGMController.cs
@@ -47,7 +47,7 @@ public class BGMController
     
     // The event that fires when the game changes songs.
     public delegate void SongChangedHandler(int oldSong, int currentSong, int oldSecondSong, int secondSong);
-    public SongChangedHandler OnSongChanged;
+    public event SongChangedHandler OnSongChanged;
     
     private unsafe delegate DisableRestart* AddDisableRestartIdPrototype(BGMScene* scene, ushort songId);
     private readonly AddDisableRestartIdPrototype _addDisableRestartId;

--- a/Orchestrion/DalamudApi.cs
+++ b/Orchestrion/DalamudApi.cs
@@ -1,4 +1,3 @@
-﻿using Dalamud.Game;
 using Dalamud.IoC;
 using Dalamud.Plugin;
 using Dalamud.Plugin.Services;
@@ -9,31 +8,33 @@ public class DalamudApi
 {
     public static void Initialize(IDalamudPluginInterface pluginInterface) => pluginInterface.Create<DalamudApi>();
 
-    // [PluginService] public static IAetheryteList AetheryteList { get; private set; } = null;
-    // [PluginService] public static IBuddyList BuddyList { get; private set; } = null;    
-    [PluginService] public static IChatGui ChatGui { get; private set; } = null;
-    [PluginService] public static IClientState ClientState { get; private set; } = null;
-    [PluginService] public static ICommandManager CommandManager { get; private set; } = null;
-    // [PluginService] public static ICondition Condition { get; private set; } = null;
-    [PluginService] public static IDalamudPluginInterface PluginInterface { get; private set; } = null;
-    [PluginService] public static IDataManager DataManager { get; private set; } = null;
-    [PluginService] public static IDtrBar DtrBar { get; private set; } = null;
-    // [PluginService] public static IFateTable FateTable { get; private set; } = null;
-    // [PluginService] public static IFlyTextGui FlyTextGui { get; private set; } = null;
-    [PluginService] public static IFramework Framework { get; private set; } = null;
-    [PluginService] public static IGameGui GameGui { get; private set; } = null;
-    // [PluginService] public static IGameNetwork GameNetwork { get; private set; } = null;
-    // [PluginService] public static IGamepadState GamePadState { get; private set; } = null;
-    // [PluginService] public static IJobGauges JobGauges { get; private set; } = null;
-    // [PluginService] public static IKeyState KeyState { get; private set; } = null;
-    // [PluginService] public static ILibcFunction LibcFunction { get; private set; } = null;
-    // [PluginService] public static IObjectTable ObjectTable { get; private set; } = null;
-    // [PluginService] public static IPartyFinderGui PartyFinderGui { get; private set; } = null;
-    // [PluginService] public static IPartyList PartyList { get; private set; } = null;
-    [PluginService] public static ISigScanner SigScanner { get; private set; } = null;
-    // [PluginService] public static ITargetManager TargetManager { get; private set; } = null;
-    // [PluginService] public static IToastGui ToastGui { get; private set; } = null;
-    [PluginService] public static IGameInteropProvider Hooks { get; private set; } = null;
-    [PluginService] public static IPluginLog PluginLog { get; private set; } = null;
-    // [PluginService] public static ITitleScreenMenu TitleScreenMenu { get; private set; } = null;
+    #pragma warning disable CS8618
+    // [PluginService] public static IAetheryteList AetheryteList { get; private set; }
+    // [PluginService] public static IBuddyList BuddyList { get; private set; }
+    [PluginService] public static IChatGui ChatGui { get; private set; }
+    [PluginService] public static IClientState ClientState { get; private set; }
+    [PluginService] public static ICommandManager CommandManager { get; private set; }
+    // [PluginService] public static ICondition Condition { get; private set; }
+    [PluginService] public static IDalamudPluginInterface PluginInterface { get; private set; }
+    [PluginService] public static IDataManager DataManager { get; private set; }
+    [PluginService] public static IDtrBar DtrBar { get; private set; }
+    // [PluginService] public static IFateTable FateTable { get; private set; }
+    // [PluginService] public static IFlyTextGui FlyTextGui { get; private set; }
+    [PluginService] public static IFramework Framework { get; private set; }
+    [PluginService] public static IGameGui GameGui { get; private set; }
+    [PluginService] public static IGameInteropProvider Hooks { get; private set; }
+    // [PluginService] public static IGameNetwork GameNetwork { get; private set; }
+    // [PluginService] public static IGamepadState GamePadState { get; private set; }
+    // [PluginService] public static IJobGauges JobGauges { get; private set; }
+    // [PluginService] public static IKeyState KeyState { get; private set; }
+    // [PluginService] public static ILibcFunction LibcFunction { get; private set; }
+    // [PluginService] public static IObjectTable ObjectTable { get; private set; }
+    // [PluginService] public static IPartyFinderGui PartyFinderGui { get; private set; }
+    // [PluginService] public static IPartyList PartyList { get; private set; }
+    [PluginService] public static IPluginLog PluginLog { get; private set; }
+    [PluginService] public static ISigScanner SigScanner { get; private set; }
+    // [PluginService] public static ITargetManager TargetManager { get; private set; }
+    // [PluginService] public static IToastGui ToastGui { get; private set; }
+    // [PluginService] public static ITitleScreenMenu TitleScreenMenu { get; private set; }
+    #pragma warning restore CS8618
 }

--- a/Orchestrion/InnSystem/OrchestrionInnAddressResolver.cs
+++ b/Orchestrion/InnSystem/OrchestrionInnAddressResolver.cs
@@ -1,0 +1,48 @@
+using Dalamud.Game;
+using Dalamud.Plugin.Services;
+using Dalamud.Utility.Signatures;
+
+namespace Orchestrion.InnSystem;
+
+internal class OrchestrionInnAddressResolver : BaseAddressResolver
+{
+    [Signature("88 05 ?? ?? ?? ?? 89 1D ?? ?? ?? ??", ScanType = ScanType.StaticAddress)]
+    public IntPtr PlaybackMode { get; private set; }
+
+    [Signature("C7 05 ?? ?? ?? ?? ?? ?? ?? ?? 41 0F B7 CF", ScanType = ScanType.StaticAddress)]
+    public IntPtr PlaybackState { get; private set; }
+
+    [Signature("66 44 89 3D ?? ?? ?? ?? 4D 8B E0", ScanType = ScanType.StaticAddress)]
+    public IntPtr PlayingTrackId { get; private set; }
+
+    [Signature("66 89 35 ?? ?? ?? ?? F3 0F 10 02", ScanType = ScanType.StaticAddress)]
+    public IntPtr SamplingTrackId { get; private set; }
+
+    protected override void Setup64Bit(ISigScanner scanner) => DalamudApi.Hooks.InitializeFromAttributes(this);
+
+    internal OrchestrionInnPlaybackMode GetInnPlaybackMode() => (OrchestrionInnPlaybackMode)GetInnPlaybackModeRaw();
+    internal OrchestrionInnPlaybackState GetInnPlaybackState() => (OrchestrionInnPlaybackState)GetInnPlaybackStateRaw();
+    internal uint GetInnPlayingTrackId() => GetInnPlayingTrackIdRaw();
+    internal uint GetInnSamplingTrackId() => GetInnSamplingTrackIdRaw();
+
+    private uint GetInnPlaybackModeRaw()
+    {
+        uint returnValue = (uint)Marshal.ReadInt32(PlaybackMode);
+        return returnValue;
+    }
+    private uint GetInnPlaybackStateRaw()
+    {
+        uint returnValue = (uint)Marshal.ReadInt32(PlaybackState);
+        return returnValue;
+    }
+    private ushort GetInnPlayingTrackIdRaw()
+    {
+        ushort returnValue = (ushort)Marshal.ReadInt16(PlayingTrackId);
+        return returnValue;
+    }
+    private ushort GetInnSamplingTrackIdRaw()
+    {
+        ushort returnValue = (ushort)Marshal.ReadInt16(SamplingTrackId);
+        return returnValue;
+    }
+}

--- a/Orchestrion/InnSystem/OrchestrionInnController.cs
+++ b/Orchestrion/InnSystem/OrchestrionInnController.cs
@@ -1,0 +1,144 @@
+using System.Threading;
+using Orchestrion.Persistence;
+
+namespace Orchestrion.InnSystem;
+
+internal class OrchestrionInnController
+{
+    private readonly OrchestrionInnAddressResolver InnAddressResolver = new OrchestrionInnAddressResolver();
+    private readonly Lock InnTrackDataAccessLock = new Lock();
+
+    private OrchestrionInnPlaybackMode NewInnPlaybackMode = OrchestrionInnPlaybackMode.None;
+    private OrchestrionInnPlaybackState NewInnPlaybackState = OrchestrionInnPlaybackState.None;
+    private uint NewInnSamplingTrackId = 0;
+    private uint NewInnPlayingTrackId = 0;
+    private string NewInnTrackDtrName = string.Empty;
+    private string NewInnTrackChatName = string.Empty;
+
+    private OrchestrionInnPlaybackMode OldInnPlaybackMode = OrchestrionInnPlaybackMode.None;
+    private OrchestrionInnPlaybackState OldInnPlaybackState = OrchestrionInnPlaybackState.None;
+    private uint OldInnSamplingTrackId = 0;
+    private uint OldInnPlayingTrackId = 0;
+    private string OldInnTrackDtrName = string.Empty;
+    private string OldInnTrackChatName = string.Empty;
+
+    internal delegate void InnPlayingSongChangedHandler(
+        uint oldPlayingTrackId, uint newPlayingTrackId,
+        string oldInnTrackDtrName, string newInnTrackDtrName, string newInnTrackChatName
+    );
+    internal event InnPlayingSongChangedHandler? OnPlayingSongChanged;
+
+    internal OrchestrionInnController()
+    {
+        InnAddressResolver.Setup(DalamudApi.SigScanner);
+        ResetAllFieldValues();
+    }
+
+    internal bool IsInnTrackPlaying() => NewInnPlaybackState != OrchestrionInnPlaybackState.None;
+    internal bool IsInnTrackSampling() => NewInnPlaybackState == OrchestrionInnPlaybackState.Sampling;
+
+    internal void Update()
+    {
+        lock (InnTrackDataAccessLock)
+        {
+            bool innTrackChanged = UpdateFieldValues();
+
+            if (innTrackChanged)
+            {
+                HandleNewInnTrack();
+            }
+
+            RecordOldFieldValues();
+        }
+    }
+
+    private void HandleNewInnTrack()
+    {
+        string ServerInfoLanguageCode = Configuration.Instance.ServerInfoLanguageCode;
+        string ChatLanguageCode = Configuration.Instance.ChatLanguageCode;
+
+        if (IsInnTrackPlaying())
+        {
+            NewInnTrackDtrName = GetInnTrackName(NewInnPlayingTrackId, ServerInfoLanguageCode);
+            NewInnTrackChatName = GetInnTrackName(NewInnPlayingTrackId, ChatLanguageCode);
+        }
+
+        OnPlayingSongChanged?.Invoke(
+            OldInnPlayingTrackId, NewInnPlayingTrackId,
+            OldInnTrackDtrName, NewInnTrackDtrName, NewInnTrackChatName
+        );
+    }
+
+    private string GetInnTrackName(uint trackId, string languageCode)
+    {
+        string innTrackName;
+
+        try
+        {
+            innTrackName = DalamudApi.DataManager.Excel.GetSheet<Lumina.Excel.Sheets.Orchestrion>(
+                language: Util.LangCodeToLuminaLanguage(languageCode)
+            ).GetRow(trackId).Name.ToString();
+        }
+        catch (Exception ex)
+        {
+            DalamudApi.PluginLog.Warning(ex, $"[OrchestrionInnController::GetInnTrackName] Exception thrown while looking up chat name for new inn song with track ID {trackId} and language code {languageCode}, falling back to English");
+            innTrackName = DalamudApi.DataManager.Excel.GetSheet<Lumina.Excel.Sheets.Orchestrion>(
+                language: Lumina.Data.Language.English
+            ).GetRow(trackId).Name.ToString();
+        }
+
+        return innTrackName;
+    }
+
+    private bool UpdateFieldValues()
+    {
+        NewInnPlaybackMode = InnAddressResolver.GetInnPlaybackMode();
+        NewInnPlaybackState = InnAddressResolver.GetInnPlaybackState();
+        NewInnPlayingTrackId = IsInnTrackPlaying() ? InnAddressResolver.GetInnPlayingTrackId() : OldInnPlayingTrackId;
+        NewInnSamplingTrackId = IsInnTrackSampling() ? InnAddressResolver.GetInnSamplingTrackId() : OldInnSamplingTrackId;
+
+        if (OldInnPlaybackState != OrchestrionInnPlaybackState.None && NewInnPlaybackState == OrchestrionInnPlaybackState.None)
+        {
+            ResetNewFieldValues();
+        }
+
+        bool innTrackChanged = NewInnPlayingTrackId != OldInnPlayingTrackId;
+        return innTrackChanged;
+    }
+
+    private void ResetNewFieldValues()
+    {
+        NewInnPlaybackMode = OrchestrionInnPlaybackMode.None;
+        NewInnPlaybackState = OrchestrionInnPlaybackState.None;
+        NewInnSamplingTrackId = 0;
+        NewInnPlayingTrackId = 0;
+        NewInnTrackDtrName = string.Empty;
+        NewInnTrackChatName = string.Empty;
+    }
+
+    private void ResetOldFieldValues()
+    {
+        OldInnPlaybackMode = OrchestrionInnPlaybackMode.None;
+        OldInnPlaybackState = OrchestrionInnPlaybackState.None;
+        OldInnSamplingTrackId = 0;
+        OldInnPlayingTrackId = 0;
+        OldInnTrackDtrName = string.Empty;
+        OldInnTrackChatName = string.Empty;
+    }
+
+    private void ResetAllFieldValues()
+    {
+        ResetOldFieldValues();
+        ResetNewFieldValues();
+    }
+
+    private void RecordOldFieldValues()
+    {
+        OldInnPlaybackMode = NewInnPlaybackMode;
+        OldInnPlaybackState = NewInnPlaybackState;
+        OldInnSamplingTrackId = NewInnSamplingTrackId;
+        OldInnPlayingTrackId = NewInnPlayingTrackId;
+        OldInnTrackDtrName = NewInnTrackDtrName;
+        OldInnTrackChatName = NewInnTrackChatName;
+    }
+}

--- a/Orchestrion/InnSystem/OrchestrionInnPlaybackMode.cs
+++ b/Orchestrion/InnSystem/OrchestrionInnPlaybackMode.cs
@@ -1,0 +1,9 @@
+namespace Orchestrion.InnSystem;
+
+internal enum OrchestrionInnPlaybackMode
+{
+    None = 0,
+    PlayAll = 1,
+    Shuffle = 2,
+    Repeat = 3
+}

--- a/Orchestrion/InnSystem/OrchestrionInnPlaybackState.cs
+++ b/Orchestrion/InnSystem/OrchestrionInnPlaybackState.cs
@@ -1,0 +1,9 @@
+namespace Orchestrion.InnSystem;
+
+internal enum OrchestrionInnPlaybackState
+{
+    None = 0,
+    Playing = 1,
+    Sampling = 2,
+    Unknown = 3
+}

--- a/Orchestrion/Orchestrion.csproj
+++ b/Orchestrion/Orchestrion.csproj
@@ -10,10 +10,6 @@
     <Authors>Meli, perchbird</Authors>
     <Copyright>Copyright ©  2021</Copyright>
     <OutputPath>bin\$(Configuration)\</OutputPath>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
-    <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
     <Version>$(PluginVersion)</Version>
     <FileVersion>$(PluginVersion)</FileVersion>
     <AssemblyVersion>$(PluginVersion)</AssemblyVersion>

--- a/Orchestrion/OrchestrionPlugin.cs
+++ b/Orchestrion/OrchestrionPlugin.cs
@@ -1,30 +1,32 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.IO;
-using Dalamud.Game.Command;
-using Dalamud.Game.Text;
-using Dalamud.Plugin;
 using System.Linq;
 using System.Reflection;
 using CheapLoc;
 using Dalamud;
+using Dalamud.Game.Command;
 using Dalamud.Game.Gui.Dtr;
+using Dalamud.Game.Text;
 using Dalamud.Game.Text.SeStringHandling;
 using Dalamud.Interface;
 using Dalamud.Interface.GameFonts;
 using Dalamud.Interface.ManagedFontAtlas;
 using Dalamud.Interface.Windowing;
+using Dalamud.Plugin;
 using Dalamud.Plugin.Services;
+using Dalamud.Utility;
 using FFXIVClientStructs.FFXIV.Component.GUI;
 using Orchestrion.Audio;
 using Orchestrion.BGMSystem;
 using Orchestrion.Persistence;
 using Orchestrion.UI.Windows;
+
 using MainWindow = Orchestrion.UI.Windows.MainWindow.MainWindow;
 
 namespace Orchestrion;
 
 // ReSharper disable once ClassNeverInstantiated.Global
-public class OrchestrionPlugin : IDalamudPlugin
+public class OrchestrionPlugin : IDalamudPlugin, IDisposable
 {
 	private const string ConstName = "Orchestrion";
 	private const string CommandName = "/porch";
@@ -48,9 +50,14 @@ public class OrchestrionPlugin : IDalamudPlugin
 	{
 		DalamudApi.Initialize(pi);
 		LanguageChanged(DalamudApi.PluginInterface.UiLanguage);
+
+		_dtrEntry = DalamudApi.DtrBar.Get(ConstName);
+		_dtrEntry.Shown = Configuration.Instance.ShowSongInNative;
+		_dtrEntry.OnClick = args => _mainWindow.Toggle();
 		
 		BGMAddressResolver.Init();
 		BGMManager.OnSongChanged += OnSongChanged;
+		BGMManager.OnInnSongPlayed += UpdateInnSongInfo;
 
 		_windowSystem = new WindowSystem();
 		_mainWindow = new MainWindow(this);
@@ -60,10 +67,6 @@ public class OrchestrionPlugin : IDalamudPlugin
 		_windowSystem.AddWindow(_mainWindow);
 		_windowSystem.AddWindow(_settingsWindow);
 		_windowSystem.AddWindow(_miniPlayerWindow);
-		
-		_dtrEntry = DalamudApi.DtrBar.Get(ConstName);
-		_dtrEntry.Shown = Configuration.Instance.ShowSongInNative;
-		_dtrEntry.OnClick = args => _mainWindow.Toggle();
 
 		DalamudApi.CommandManager.AddHandler(CommandName, new CommandInfo(OnCommand)
 		{
@@ -113,14 +116,27 @@ public class OrchestrionPlugin : IDalamudPlugin
 	
 	public void Dispose()
 	{
-		_mainWindow.Dispose();
+		DalamudApi.PluginInterface.LanguageChanged -= LanguageChanged;
+
+		DalamudApi.ClientState.Logout -= ClientStateOnLogout;
 		DalamudApi.Framework.Update -= OrchestrionUpdate;
-		DalamudApi.PluginInterface.UiBuilder.Draw -= _windowSystem.Draw;
-		// DalamudApi.PluginInterface.UiBuilder.BuildFonts -= BuildFonts;
-		DalamudApi.CommandManager.RemoveHandler(CommandName);
-		_dtrEntry?.Remove();
+
+		BGMManager.OnInnSongPlayed -= UpdateInnSongInfo;
+		BGMManager.OnSongChanged -= OnSongChanged;
+
 		PlaylistManager.Dispose();
 		BGMManager.Dispose();
+
+		_dtrEntry?.Remove();
+
+		DalamudApi.CommandManager.RemoveHandler(CommandName);
+
+		DalamudApi.PluginInterface.UiBuilder.OpenConfigUi -= OpenSettingsWindow;
+		DalamudApi.PluginInterface.UiBuilder.Draw -= _windowSystem.Draw;
+		_windowSystem.RemoveAllWindows();
+		_mainWindow.Dispose();
+
+		// DalamudApi.PluginInterface.UiBuilder.BuildFonts -= BuildFonts;
 		LargeFont?.Dispose();
 		CnFont?.Dispose();
 	}
@@ -459,11 +475,30 @@ public class OrchestrionPlugin : IDalamudPlugin
 	{
 		if (!Configuration.Instance.ShowSongInChat) return;
 		if (!SongList.Instance.TryGetSong(songId, out var song)) return;
+		if (!DalamudApi.ClientState.IsLoggedIn) return;
 		var songName = song.Strings[Configuration.Instance.ChatLanguageCode].Name;
 
 		// the actual echoing is done during framework update
 		if (!string.IsNullOrEmpty(songName))
 			_songEchoMsg = BuildChatMessageFormatted(Loc.Localize("NowPlayingEcho", "Now playing <i>{0}</i>."), songName, playedByOrch);
+	}
+
+	private void UpdateInnSongInfo(string trackDtrName, string trackChatName)
+	{
+		if (!trackDtrName.IsNullOrWhitespace() && _dtrEntry != null)
+		{
+			// UpdateDtr - mini
+			_dtrEntry.Text = $"{NativeNowPlayingPrefix} {trackDtrName}";
+			_dtrEntry.Tooltip = "";
+		}
+
+		if (!trackChatName.IsNullOrWhitespace())
+		{
+			// UpdateChat - mini
+			if (!Configuration.Instance.ShowSongInChat) return;
+			if (!DalamudApi.ClientState.IsLoggedIn) return;
+			_songEchoMsg = BuildChatMessageFormatted(Loc.Localize("NowPlayingEcho", "Now playing <i>{0}</i>."), trackChatName, false);
+		}
 	}
 
 	private unsafe bool IsLoadingScreen()

--- a/Orchestrion/UI/Windows/MainWindow/MainWindow.Root.cs
+++ b/Orchestrion/UI/Windows/MainWindow/MainWindow.Root.cs
@@ -1,13 +1,12 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
 using CheapLoc;
+using Dalamud.Bindings.ImGui;
 using Dalamud.Interface;
 using Dalamud.Interface.Components;
 using Dalamud.Interface.Utility;
 using Dalamud.Interface.Windowing;
-using Dalamud.Logging;
-using Dalamud.Bindings.ImGui;
 using Orchestrion.Audio;
 using Orchestrion.Persistence;
 using Orchestrion.Types;
@@ -79,6 +78,7 @@ public partial class MainWindow : Window, IDisposable
 			});
 
 		BGMManager.OnSongChanged += SongChanged;
+		BGMManager.OnInnSongPlayed += UpdateInnSongInfo;
 		ResetReplacement();
 	}
 
@@ -102,9 +102,20 @@ public partial class MainWindow : Window, IDisposable
 		}
 	}
 
+	internal void UpdateInnSongInfo(string trackDtrName, string trackChatName)
+	{
+		if (Configuration.Instance.ShowSongInTitleBar)
+		{
+			DalamudApi.PluginLog.Debug("[MainWindow.Root::UpdateInnSongInfo] Updating title bar");
+			WindowName = $"Orchestrion - {trackDtrName}###Orchestrion";
+		}
+	}
+
 	public void Dispose()
 	{
 		BGMManager.Stop();
+		BGMManager.OnInnSongPlayed -= UpdateInnSongInfo;
+		BGMManager.OnSongChanged -= SongChanged;
 	}
 
 	private void ResetReplacement()

--- a/Orchestrion/Util.cs
+++ b/Orchestrion/Util.cs
@@ -1,10 +1,10 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Numerics;
-using Dalamud;
 using System.Reflection;
 using Dalamud.Interface;
 using Dalamud.Bindings.ImGui;
+using Lumina.Data;
 using Orchestrion.Persistence;
 using Orchestrion.Types;
 
@@ -18,6 +18,17 @@ public static class Util
 	public static string LangCodeToLanguage(string code)
 	{
 		return CultureInfo.GetCultureInfo(code).NativeName;
+	}
+
+	public static Language LangCodeToLuminaLanguage(string code)
+	{
+		return code switch
+		{
+			// Orchestrion song titles in the EXD sheets are currently only available in English and Japanese
+			"en" => Language.English,
+			"ja" => Language.Japanese,
+			_ => Language.English
+		};
 	}
 	
 	public static Vector2 GetIconSize(FontAwesomeIcon icon)

--- a/Orchestrion/orchestrion.yaml
+++ b/Orchestrion/orchestrion.yaml
@@ -10,4 +10,11 @@ repo_url: https://github.com/perchbirdd/OrchestrionPlugin
 tags:
   - bgm
   - music
-changelog: Update for 6.2.
+changelog: |-
+  Update for 7.4.
+  Orchestrion (the plugin) can now report the titles of songs played inside housing instances by orchestrions (the furniture items).
+  Limitations:
+  - This plugin still cannot play Orchestrion rolls.
+  - Titles of songs played inside housing instances can appear in the server bar and in chat messages.
+  - Songs played inside housing instances will not appear in your listening history and cannot be added to playlists.
+  - Titles of songs played inside housing instances currently only display in English or Japanese.


### PR DESCRIPTION
Updated for 7.4!

Orchestrion (the plugin) can now report the titles of songs played inside housing instances by orchestrions (the furniture items).

Limitations:
- This plugin still cannot play Orchestrion rolls.
- Titles of songs played inside housing instances can appear in the server bar and in chat messages.
- Songs played inside housing instances will not appear in your listening history and cannot be added to playlists.
- Titles of songs played inside housing instances currently only display in English or Japanese.

Resolves https://github.com/perchbirdd/OrchestrionPlugin/issues/1