### PR TITLE
Update for 7.5 and API 15

### DIFF
--- a/Orchestrion/Orchestrion.csproj
+++ b/Orchestrion/Orchestrion.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Dalamud.NET.Sdk/15.0.0">
   <PropertyGroup>
-    <PluginVersion>2.2.0.12</PluginVersion>
+		<PluginVersion>2.2.0.13</PluginVersion>
   </PropertyGroup>
   
   <PropertyGroup>

--- a/Orchestrion/Orchestrion.csproj
+++ b/Orchestrion/Orchestrion.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Dalamud.NET.Sdk/14.0.1">
+<Project Sdk="Dalamud.NET.Sdk/15.0.0">
   <PropertyGroup>
     <PluginVersion>2.2.0.12</PluginVersion>
   </PropertyGroup>
@@ -16,12 +16,25 @@
   </PropertyGroup>
   
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugType>full</DebugType>
+		<DebugType>portable</DebugType>
+		<DebugSymbols>true</DebugSymbols>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+		<DebugType>portable</DebugType>
+		<DebugSymbols>true</DebugSymbols>
+	</PropertyGroup>
+
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">
+		<DebugType>portable</DebugType>
+		<DebugSymbols>true</DebugSymbols>
+		<DefineConstants>DEBUG;TRACE</DefineConstants>
+	</PropertyGroup>
+
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
+		<DebugType>portable</DebugType>
+		<DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <ItemGroup>
@@ -78,4 +91,8 @@
     <None Remove="Loc\zh.json" />
     <EmbeddedResource Include="Loc\zh.json" />
   </ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Update="DalamudPackager" Version="15.0.0" />
+	</ItemGroup>
 </Project>

--- a/Orchestrion/OrchestrionPlugin.cs
+++ b/Orchestrion/OrchestrionPlugin.cs
@@ -93,12 +93,12 @@ public class OrchestrionPlugin : IDalamudPlugin, IDisposable
 					.Concat(Enumerable.Range(1, 127).Select(x => (char)x))
 					.ToGlyphRange(),
 			};
-			tk.Font = tk.AddDalamudAssetFont(DalamudAsset.NotoSansJpMedium, config);
+			tk.Font = tk.AddDalamudAssetFont(DalamudAsset.NotoSansCjkMedium, config);
 		}));
 		if (CnFont.LoadException != null)
 		{
 			DalamudApi.PluginLog.Debug(CnFont.LoadException.Message);	
-			DalamudApi.PluginLog.Debug(CnFont.LoadException.StackTrace);	
+			DalamudApi.PluginLog.Debug(CnFont.LoadException?.StackTrace ?? "<no stacktrace>");	
 		}
 		
 		LargeFont = atlas.NewGameFontHandle(new GameFontStyle(GameFontFamily.Axis, 24));

--- a/Orchestrion/packages.lock.json
+++ b/Orchestrion/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0-windows7.0": {
       "DalamudPackager": {
         "type": "Direct",
-        "requested": "[14.0.1, )",
-        "resolved": "14.0.1",
-        "contentHash": "y0WWyUE6dhpGdolK3iKgwys05/nZaVf4ZPtIjpLhJBZvHxkkiE23zYRo7K7uqAgoK/QvK5cqF6l3VG5AbgC6KA=="
+        "requested": "[15.0.0, )",
+        "resolved": "15.0.0",
+        "contentHash": "411vwC8/X8Z/sQ2TI6v3SvOn66xFPeOjFn3Zn+h0d3Ox2t1kFm66AhDvmx/qcMwVrR+Hidxj0dadpQ2dgyXMBQ=="
       },
       "DotNet.ReproducibleBuilds": {
         "type": "Direct",


### PR DESCRIPTION
Update to latest Dalamud API 15, as far as I am aware with my limited testing there are no broken features and all works fine as a drop in. 

There was one minor API change and that was just a font reference.

I did have to remove Any CPU to build on my end, I am not sure if that was a issue with my setup or the plugin so I did not push it in.
```diff
diff --git a/Orchestrion.sln b/Orchestrion.sln
index 37437a3..ec94aec 100644
--- a/Orchestrion.sln
+++ b/Orchestrion.sln
@@ -7,14 +7,14 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Orchestrion", "Orchestrion\
 EndProject
 Global
        GlobalSection(SolutionConfigurationPlatforms) = preSolution
-               Debug|Any CPU = Debug|Any CPU
-               Release|Any CPU = Release|Any CPU
+               Debug|x64 = Debug|x64
+               Release|x64 = Release|x64
        EndGlobalSection
        GlobalSection(ProjectConfigurationPlatforms) = postSolution
-               {F75C1B2F-FD6F-4588-B06C-6AEE7804EDEB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-               {F75C1B2F-FD6F-4588-B06C-6AEE7804EDEB}.Debug|Any CPU.Build.0 = Debug|Any CPU
-               {F75C1B2F-FD6F-4588-B06C-6AEE7804EDEB}.Release|Any CPU.ActiveCfg = Release|Any CPU
-               {F75C1B2F-FD6F-4588-B06C-6AEE7804EDEB}.Release|Any CPU.Build.0 = Release|Any CPU
+               {F75C1B2F-FD6F-4588-B06C-6AEE7804EDEB}.Debug|x64.ActiveCfg = Debug|x64
+               {F75C1B2F-FD6F-4588-B06C-6AEE7804EDEB}.Debug|x64.Build.0 = Debug|x64
+               {F75C1B2F-FD6F-4588-B06C-6AEE7804EDEB}.Release|x64.ActiveCfg = Release|x64
+               {F75C1B2F-FD6F-4588-B06C-6AEE7804EDEB}.Release|x64.Build.0 = Release|x64
        EndGlobalSection
        GlobalSection(SolutionProperties) = preSolution
                HideSolutionNode = FALSE
```